### PR TITLE
Implement accent recognition training and prediction scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pt

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # AccentRecogApp
-An accent recognition model/app using transfer learning.
+
+AccentRecogApp provides a simple accent recognition pipeline built on top of a
+pretrained [Wav2Vec2](https://arxiv.org/abs/2006.11477) model from
+`torchaudio`. Audio files are expected to be organised in subfolders named after
+the accent label (e.g. `american/`, `british/`).
+
+The training script freezes the pretrained feature extractor and trains a small
+classification head for the provided accents.
+
+## Requirements
+
+* Python 3.8+
+* `torch`
+* `torchaudio`
+
+Install the dependencies with:
+
+```bash
+pip install torch torchaudio
+```
+
+## Training
+
+Prepare a dataset directory where each accent has its own folder containing
+`.wav` files. For example:
+
+```
+/your-dataset/
+    american/
+        sample1.wav
+        sample2.wav
+    british/
+        example1.wav
+```
+
+Run the training script:
+
+```bash
+python -m accentrecog.train /your-dataset --epochs 5 --output model.pt
+```
+
+This will save `model.pt` containing the trained weights and label mapping.
+
+## Prediction
+
+After training you can predict the accent of a new `.wav` file:
+
+```bash
+python -m accentrecog.predict model.pt path/to/test.wav
+```
+
+The script prints the predicted accent label.
+
+## Project Ideas
+
+* Collect a diverse dataset of speakers from different regions to improve the
+  model's robustness.
+* Experiment with other pretrained speech models or fine-tune additional layers
+  for higher accuracy.
+* Build a simple web interface using `Flask` or `FastAPI` so users can upload
+  audio and get real‑time accent predictions.

--- a/accentrecog/__init__.py
+++ b/accentrecog/__init__.py
@@ -1,0 +1,4 @@
+"""Accent Recognition Package"""
+
+from .dataset import AccentDataset
+from .model import Wav2Vec2Classifier

--- a/accentrecog/dataset.py
+++ b/accentrecog/dataset.py
@@ -1,0 +1,31 @@
+import os
+import torchaudio
+from torch.utils.data import Dataset
+
+class AccentDataset(Dataset):
+    """Dataset that loads audio files organized by accent labels."""
+
+    def __init__(self, root_dir: str, sample_rate: int = 16000):
+        self.root_dir = root_dir
+        self.sample_rate = sample_rate
+        self.files = []
+        self.labels = []
+        for label in sorted(os.listdir(root_dir)):
+            label_path = os.path.join(root_dir, label)
+            if not os.path.isdir(label_path):
+                continue
+            for fname in os.listdir(label_path):
+                if fname.lower().endswith('.wav'):
+                    self.files.append(os.path.join(label_path, fname))
+                    self.labels.append(label)
+        self.label_to_idx = {label: idx for idx, label in enumerate(sorted(set(self.labels)))}
+
+    def __len__(self) -> int:
+        return len(self.files)
+
+    def __getitem__(self, idx):
+        waveform, sr = torchaudio.load(self.files[idx])
+        if sr != self.sample_rate:
+            waveform = torchaudio.functional.resample(waveform, sr, self.sample_rate)
+        label = self.label_to_idx[self.labels[idx]]
+        return waveform.squeeze(0), label

--- a/accentrecog/model.py
+++ b/accentrecog/model.py
@@ -1,0 +1,25 @@
+import torch
+from torch import nn
+import torchaudio
+
+class Wav2Vec2Classifier(nn.Module):
+    """Classifier built on top of a pretrained Wav2Vec2 model."""
+
+    def __init__(self, num_classes: int):
+        super().__init__()
+        bundle = torchaudio.pipelines.WAV2VEC2_BASE
+        self.feature_extractor = bundle.get_model()
+        for param in self.feature_extractor.parameters():
+            param.requires_grad = False
+        self.classifier = nn.Sequential(
+            nn.Linear(bundle._params["encoder_embed_dim"], 256),
+            nn.ReLU(),
+            nn.Dropout(0.1),
+            nn.Linear(256, num_classes),
+        )
+
+    def forward(self, waveforms: torch.Tensor) -> torch.Tensor:
+        with torch.inference_mode():
+            features, _ = self.feature_extractor.extract_features(waveforms)
+        x = features[-1].mean(dim=1)
+        return self.classifier(x)

--- a/accentrecog/predict.py
+++ b/accentrecog/predict.py
@@ -1,0 +1,32 @@
+import argparse
+import torch
+import torchaudio
+
+from .model import Wav2Vec2Classifier
+
+
+def predict(args):
+    checkpoint = torch.load(args.model, map_location="cpu")
+    label_to_idx = checkpoint["label_to_idx"]
+    idx_to_label = {v: k for k, v in label_to_idx.items()}
+    model = Wav2Vec2Classifier(len(label_to_idx))
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+
+    waveform, sr = torchaudio.load(args.audio)
+    if sr != 16000:
+        waveform = torchaudio.functional.resample(waveform, sr, 16000)
+
+    with torch.no_grad():
+        output = model(waveform)
+        pred = output.argmax(dim=-1).item()
+
+    print(idx_to_label[pred])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Predict accent of an audio file")
+    parser.add_argument("model", help="Path to trained model file")
+    parser.add_argument("audio", help="Audio file (.wav) to classify")
+    args = parser.parse_args()
+    predict(args)

--- a/accentrecog/train.py
+++ b/accentrecog/train.py
@@ -1,0 +1,54 @@
+import argparse
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
+
+from .dataset import AccentDataset
+from .model import Wav2Vec2Classifier
+
+
+def collate_fn(batch):
+    waveforms, labels = zip(*batch)
+    waveforms = nn.utils.rnn.pad_sequence(waveforms, batch_first=True)
+    labels = torch.tensor(labels)
+    return waveforms, labels
+
+
+def train(args):
+    dataset = AccentDataset(args.data_dir)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn)
+    model = Wav2Vec2Classifier(len(dataset.label_to_idx))
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.classifier.parameters(), lr=args.lr)
+
+    model.train()
+    for epoch in range(args.epochs):
+        total_loss = 0.0
+        for waveforms, labels in loader:
+            waveforms, labels = waveforms.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(waveforms)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+        avg_loss = total_loss / len(loader)
+        print(f"Epoch {epoch + 1}: loss {avg_loss:.4f}")
+
+    torch.save({
+        'model_state_dict': model.state_dict(),
+        'label_to_idx': dataset.label_to_idx,
+    }, args.output)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train accent recognition model")
+    parser.add_argument("data_dir", help="Directory with accent-labeled subfolders")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--output", default="accent_model.pt")
+    args = parser.parse_args()
+    train(args)


### PR DESCRIPTION
## Summary
- implement `accentrecog` package with dataset, model, training and prediction scripts
- document usage and project ideas in README
- add a simple `.gitignore`

## Testing
- `python3 -m py_compile accentrecog/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685dce188a58832197ed7c5b36ebd169