### PR TITLE
Add simple Flask frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ classification head for the provided accents.
 * Python 3.8+
 * `torch`
 * `torchaudio`
+* `flask` (for the optional web interface)
 
 Install the dependencies with:
 
 ```bash
-pip install torch torchaudio
+pip install torch torchaudio flask
 ```
 
 ## Training
@@ -51,6 +52,19 @@ python -m accentrecog.predict model.pt path/to/test.wav
 ```
 
 The script prints the predicted accent label.
+
+## Web Interface
+
+You can start a simple web frontend to upload audio files and get
+predictions using `Flask`:
+
+```bash
+python webapp.py
+```
+
+By default the application looks for a model file named `accent_model.pt` in the
+current directory. Set the `MODEL_PATH` environment variable to point to a
+different model if needed.
 
 ## Project Ideas
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,57 @@
+from flask import Flask, render_template_string, request
+import os
+import tempfile
+
+from accentrecog.predict import predict_file
+
+MODEL_PATH = os.getenv("MODEL_PATH", "accent_model.pt")
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Accent Recognition</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Roboto', sans-serif; max-width: 600px; margin: 40px auto; text-align: center; }
+        h1 { font-weight: 500; }
+        form { margin-top: 20px; }
+        input[type=file], input[type=text], button { width: 100%; padding: 10px; margin: 10px 0; }
+        .result { margin-top: 20px; font-size: 1.2em; }
+    </style>
+</head>
+<body>
+    <h1>Accent Recognition</h1>
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="audio" accept=".wav" required>
+        <input type="text" name="model" placeholder="Model path" value="{{model_path}}" />
+        <button type="submit">Predict</button>
+    </form>
+    {% if result %}
+    <div class="result">Prediction: <strong>{{ result }}</strong></div>
+    {% endif %}
+</body>
+</html>
+"""
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    model_path = MODEL_PATH
+    if request.method == 'POST':
+        audio = request.files.get('audio')
+        model_path = request.form.get('model', MODEL_PATH)
+        if audio:
+            with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmp:
+                audio.save(tmp.name)
+                result = predict_file(model_path, tmp.name)
+            os.unlink(tmp.name)
+    return render_template_string(INDEX_HTML, result=result, model_path=model_path)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- expose `predict_file` function for re-use
- document optional web frontend in README
- add a minimal Flask-based web interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68815b2227b883218f5152946afcd166